### PR TITLE
Merge pull request #41 from stfsy/dependabot/github_actions/actions/s…

### DIFF
--- a/server/handlers/validation/struct-json-name-map.go
+++ b/server/handlers/validation/struct-json-name-map.go
@@ -52,7 +52,7 @@ func buildJSONFieldMap(t reflect.Type, parentKey, parentTag string) map[string]s
 		}
 		m[key] = tagPath
 		ft := f.Type
-		if ft.Kind() == reflect.Ptr {
+		if ft.Kind() == reflect.Pointer {
 			ft = ft.Elem()
 		}
 		if ft.Kind() == reflect.Struct && !f.Anonymous && ft.Name() != "Time" {

--- a/server/handlers/validation/validation.go
+++ b/server/handlers/validation/validation.go
@@ -20,7 +20,7 @@ type FieldErrorDetail struct {
 func ValidateStruct(s interface{}) map[string]FieldErrorDetail {
 	errors := make(map[string]FieldErrorDetail)
 	t := reflect.TypeOf(s)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 


### PR DESCRIPTION
## Summary
Fixes the failing `lints / Build` GitHub Actions check by updating deprecated reflect kind constant usage flagged by `govet`.

## Changes
- Replaced `reflect.Ptr` with `reflect.Pointer` in validation code paths:
  - `/home/runner/work/go-api-kit/go-api-kit/server/handlers/validation/validation.go`
  - `/home/runner/work/go-api-kit/go-api-kit/server/handlers/validation/struct-json-name-map.go`

## Validation
- `go test ./...` passed
- `./lint.sh` passed (`0 issues`)
- Secret scan passed on changed files
- CodeQL check run (trivial-change classification)